### PR TITLE
ci: skip no-commit-to-branch hook in prek workflow

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -10,3 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d  # v2.0.4
+        env:
+          # `no-commit-to-branch` guards local commits to protected branches.
+          # In CI the runner is checked out on `main`, so it always fails — skip it.
+          SKIP: no-commit-to-branch


### PR DESCRIPTION
## Summary

The `prek-checks` workflow was failing on every push to `main` ([example run](https://github.com/hasansezertasan/hasansezertasan/actions/runs/27867279088)).

The culprit was the builtin `no-commit-to-branch` hook (`prek.toml:21`). That hook is a **local commit guard** — its job is to abort a `git commit` when you're on a protected branch (default `main`/`master`). In CI, `prek-action` runs `prek run --all-files` at the `pre-commit` stage while the runner is checked out on `main`, so the hook fails by design on every push — independent of the actual changes.

## Fix

Set `SKIP=no-commit-to-branch` on the `prek-action` step so the hook is excluded in CI while remaining active for local commits.

## Notes

This needs to land on `main` to fix the failing push job there.

## Summary by Sourcery

CI:
- Configure the prek GitHub Action to skip the no-commit-to-branch hook when running in CI.