### PR TITLE
fix(lint): allowlist "seh" in typos to stop pronunciation false positive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = ["mkdocs-material==9.7.6"]
 [tool.typos.default.extend-words]
 # "Paket Mutfak" is a company name (Turkish for "Package Kitchen"), not a typo of "Packet".
 Paket = "Paket"
+# "seh" is a phonetic syllable in the pronunciation guide "seh-ZEHR" (Sezer), not a typo of "she".
+seh = "seh"
 
 [tool.pymarkdown]
 # Align pymarkdown with the existing `.markdownlint.json` settings so the three


### PR DESCRIPTION
## Summary

CI was failing on the `typos` pre-commit hook. It treated `seh` in the README pronunciation guide `*seh-ZEHR*` (Sezer) as a misspelling of `she` and auto-rewrote it. Because a hook modified a file, `prek` exited non-zero.

The auto-correction was also semantically wrong — it would have corrupted the intended phonetic spelling of the name.

## Fix

Add `seh = "seh"` to `[tool.typos.default.extend-words]` so typos treats it as a valid word (same pattern as the existing `Paket = "Paket"` entry).

## Verification

`prek run typos --all-files` → **Passed** locally. README content is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spelling validation to recognize “seh” as an intentional phonetic term.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->